### PR TITLE
inital version of SDK Plugins only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,12 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
-replay_pid*
+
+# SDKs
+gwt-2.8.2/
+gwt-2.9.0/
+gwt-2.10.1/
+gwt-2.11.0/
+
+# Target
+target/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # gwt-sdk-plugins
-This repo is used to build the SDK Plugins separately from the main eclipse plugin
+This Project builds the GWT SDK Plugins for the GWT Plugin. This allows you to install the SDKs by using the Marketplace or an other repository into eclipse.
+Alternativly you can simply download the GWT SDK from the GWT projekts website, and reference it in the eclipse preferences.
+
+## build
+To build the SDK Plugins you can simply use ***mvn clean install***. The Update Site will be created in ***repo/target/repository***

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt210.feature/.project
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt210.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.gwtplugins.eclipse.sdkbundle.gwt29.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt210.feature/.settings/org.eclipse.m2e.core.prefs
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt210.feature/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt210.feature/build.properties
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt210.feature/build.properties
@@ -1,0 +1,3 @@
+bin.includes = feature.xml,\
+               feature.properties
+               

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt210.feature/feature.properties
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt210.feature/feature.properties
@@ -1,0 +1,131 @@
+featureName  = GWT 2.10.1 SDK
+providerName = GWT Eclipse Plugin
+description = Downloads the GWT 2.10.1 SDK library 
+licenseURL = https://github.com/gwt-plugins/gwt-eclipse-plugin/blob/master/LICENSE.md
+
+# "license" property - text of the "Feature Update License"
+# should be plain text version of license agreement pointed to be "licenseURL"
+license=\
+Eclipse Foundation Software User Agreement\n\
+April 9, 2014\n\
+\n\
+Usage Of Content\n\
+\n\
+THE ECLIPSE FOUNDATION MAKES AVAILABLE SOFTWARE, DOCUMENTATION, INFORMATION AND/OR\n\
+OTHER MATERIALS FOR OPEN SOURCE PROJECTS (COLLECTIVELY "CONTENT").\n\
+USE OF THE CONTENT IS GOVERNED BY THE TERMS AND CONDITIONS OF THIS\n\
+AGREEMENT AND/OR THE TERMS AND CONDITIONS OF LICENSE AGREEMENTS OR\n\
+NOTICES INDICATED OR REFERENCED BELOW.  BY USING THE CONTENT, YOU\n\
+AGREE THAT YOUR USE OF THE CONTENT IS GOVERNED BY THIS AGREEMENT\n\
+AND/OR THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS\n\
+OR NOTICES INDICATED OR REFERENCED BELOW.  IF YOU DO NOT AGREE TO THE\n\
+TERMS AND CONDITIONS OF THIS AGREEMENT AND THE TERMS AND CONDITIONS\n\
+OF ANY APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED\n\
+BELOW, THEN YOU MAY NOT USE THE CONTENT.\n\
+\n\
+Applicable Licenses\n\
+\n\
+Unless otherwise indicated, all Content made available by the\n\
+Eclipse Foundation is provided to you under the terms and conditions of\n\
+the Eclipse Public License Version 1.0 ("EPL"). A copy of the EPL is\n\
+provided with this Content and is also available at http://www.eclipse.org/legal/epl-v10.html.\n\
+For purposes of the EPL, "Program" will mean the Content.\n\
+\n\
+Content includes, but is not limited to, source code, object code,\n\
+documentation and other files maintained in the Eclipse Foundation source code\n\
+repository ("Repository") in software modules ("Modules") and made available\n\
+as downloadable archives ("Downloads").\n\
+\n\
+\t- Content may be structured and packaged into modules to facilitate delivering,\n\
+\t  extending, and upgrading the Content. Typical modules may include plug-ins ("Plug-ins"),\n\
+\t  plug-in fragments ("Fragments"), and features ("Features").\n\
+\t- Each Plug-in or Fragment may be packaged as a sub-directory or JAR (Java(TM) ARchive)\n\
+\t  in a directory named "plugins".\n\
+\t- A Feature is a bundle of one or more Plug-ins and/or Fragments and associated material.\n\
+\t  Each Feature may be packaged as a sub-directory in a directory named "features".\n\
+\t  Within a Feature, files named "feature.xml" may contain a list of the names and version\n\
+\t  numbers of the Plug-ins and/or Fragments associated with that Feature.\n\
+\t- Features may also include other Features ("Included Features"). Within a Feature, files\n\
+\t  named "feature.xml" may contain a list of the names and version numbers of Included Features.\n\
+\n\
+The terms and conditions governing Plug-ins and Fragments should be\n\
+contained in files named "about.html" ("Abouts"). The terms and\n\
+conditions governing Features and Included Features should be contained\n\
+in files named "license.html" ("Feature Licenses"). Abouts and Feature\n\
+Licenses may be located in any directory of a Download or Module\n\
+including, but not limited to the following locations:\n\
+\n\
+\t- The top-level (root) directory\n\
+\t- Plug-in and Fragment directories\n\
+\t- Inside Plug-ins and Fragments packaged as JARs\n\
+\t- Sub-directories of the directory named "src" of certain Plug-ins\n\
+\t- Feature directories\n\
+\n\
+Note: if a Feature made available by the Eclipse Foundation is installed using the\n\
+Provisioning Technology (as defined below), you must agree to a license ("Feature \n\
+Update License") during the installation process. If the Feature contains\n\
+Included Features, the Feature Update License should either provide you\n\
+with the terms and conditions governing the Included Features or inform\n\
+you where you can locate them. Feature Update Licenses may be found in\n\
+the "license" property of files named "feature.properties" found within a Feature.\n\
+Such Abouts, Feature Licenses, and Feature Update Licenses contain the\n\
+terms and conditions (or references to such terms and conditions) that\n\
+govern your use of the associated Content in that directory.\n\
+\n\
+THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER\n\
+TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS.\n\
+SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
+\n\
+\t- Eclipse Distribution License Version 1.0 (available at http://www.eclipse.org/licenses/edl-v1.0.html)\n\
+\t- Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
+\t- Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
+\t- Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+\t- Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\
+\n\
+IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR\n\
+TO USE OF THE CONTENT. If no About, Feature License, or Feature Update License\n\
+is provided, please contact the Eclipse Foundation to determine what terms and conditions\n\
+govern that particular Content.\n\
+\n\
+\n\Use of Provisioning Technology\n\
+\n\
+The Eclipse Foundation makes available provisioning software, examples of which include,\n\
+but are not limited to, p2 and the Eclipse Update Manager ("Provisioning Technology") for\n\
+the purpose of allowing users to install software, documentation, information and/or\n\
+other materials (collectively "Installable Software"). This capability is provided with\n\
+the intent of allowing such users to install, extend and update Eclipse-based products.\n\
+Information about packaging Installable Software is available at\n\
+http://eclipse.org/equinox/p2/repository_packaging.html ("Specification").\n\
+\n\
+You may use Provisioning Technology to allow other parties to install Installable Software.\n\
+You shall be responsible for enabling the applicable license agreements relating to the\n\
+Installable Software to be presented to, and accepted by, the users of the Provisioning Technology\n\
+in accordance with the Specification. By using Provisioning Technology in such a manner and\n\
+making it available in accordance with the Specification, you further acknowledge your\n\
+agreement to, and the acquisition of all necessary rights to permit the following:\n\
+\n\
+\t1. A series of actions may occur ("Provisioning Process") in which a user may execute\n\
+\t   the Provisioning Technology on a machine ("Target Machine") with the intent of installing,\n\
+\t   extending or updating the functionality of an Eclipse-based product.\n\
+\t2. During the Provisioning Process, the Provisioning Technology may cause third party\n\
+\t   Installable Software or a portion thereof to be accessed and copied to the Target Machine.\n\
+\t3. Pursuant to the Specification, you will provide to the user the terms and conditions that\n\
+\t   govern the use of the Installable Software ("Installable Software Agreement") and such\n\
+\t   Installable Software Agreement shall be accessed from the Target Machine in accordance\n\
+\t   with the Specification. Such Installable Software Agreement must inform the user of the\n\
+\t   terms and conditions that govern the Installable Software and must solicit acceptance by\n\
+\t   the end user in the manner prescribed in such Installable Software Agreement. Upon such\n\
+\t   indication of agreement by the user, the provisioning Technology will complete installation\n\
+\t   of the Installable Software.\n\
+\n\
+Cryptography\n\
+\n\
+Content may contain encryption software. The country in which you are\n\
+currently may have restrictions on the import, possession, and use,\n\
+and/or re-export to another country, of encryption software. BEFORE\n\
+using any encryption software, please check the country's laws,\n\
+regulations and policies concerning the import, possession, or use, and\n\
+re-export of encryption software, to see if this is permitted.\n\
+\n\
+Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.\n
+########### end of license property ##########################################

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt210.feature/feature.xml
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt210.feature/feature.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="com.gwtplugins.eclipse.sdkbundle.gwt210.feature"
+      label="%featureName"
+      version="2.10.1.qualifier"
+      provider-name="%providerName">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      Copyright 2015 to 2024
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <url>
+      <update label="GWT Eclipse Plugin Update Site" url="http://storage.googleapis.com/gwt-eclipse-plugin/v3/release"/>
+   </url>
+
+   <plugin
+         id="com.gwtplugins.gwt.eclipse.sdkbundle.gwt210"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+</feature>

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt210.feature/pom.xml
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt210.feature/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.gwtplugins.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <artifactId>com.gwtplugins.eclipse.sdkbundle.gwt210.feature</artifactId>
+  <version>2.10.1-SNAPSHOT</version>
+  <packaging>eclipse-feature</packaging>
+
+</project>

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt211.feature/build.properties
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt211.feature/build.properties
@@ -1,0 +1,3 @@
+bin.includes = feature.xml,\
+               feature.properties
+               

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt211.feature/feature.properties
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt211.feature/feature.properties
@@ -1,0 +1,131 @@
+featureName  = GWT 2.11.0 SDK
+providerName = GWT Eclipse Plugin
+description = Downloads the GWT 2.11.0 SDK library 
+licenseURL = https://github.com/gwt-plugins/gwt-eclipse-plugin/blob/master/LICENSE.md
+
+# "license" property - text of the "Feature Update License"
+# should be plain text version of license agreement pointed to be "licenseURL"
+license=\
+Eclipse Foundation Software User Agreement\n\
+April 9, 2014\n\
+\n\
+Usage Of Content\n\
+\n\
+THE ECLIPSE FOUNDATION MAKES AVAILABLE SOFTWARE, DOCUMENTATION, INFORMATION AND/OR\n\
+OTHER MATERIALS FOR OPEN SOURCE PROJECTS (COLLECTIVELY "CONTENT").\n\
+USE OF THE CONTENT IS GOVERNED BY THE TERMS AND CONDITIONS OF THIS\n\
+AGREEMENT AND/OR THE TERMS AND CONDITIONS OF LICENSE AGREEMENTS OR\n\
+NOTICES INDICATED OR REFERENCED BELOW.  BY USING THE CONTENT, YOU\n\
+AGREE THAT YOUR USE OF THE CONTENT IS GOVERNED BY THIS AGREEMENT\n\
+AND/OR THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS\n\
+OR NOTICES INDICATED OR REFERENCED BELOW.  IF YOU DO NOT AGREE TO THE\n\
+TERMS AND CONDITIONS OF THIS AGREEMENT AND THE TERMS AND CONDITIONS\n\
+OF ANY APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED\n\
+BELOW, THEN YOU MAY NOT USE THE CONTENT.\n\
+\n\
+Applicable Licenses\n\
+\n\
+Unless otherwise indicated, all Content made available by the\n\
+Eclipse Foundation is provided to you under the terms and conditions of\n\
+the Eclipse Public License Version 1.0 ("EPL"). A copy of the EPL is\n\
+provided with this Content and is also available at http://www.eclipse.org/legal/epl-v10.html.\n\
+For purposes of the EPL, "Program" will mean the Content.\n\
+\n\
+Content includes, but is not limited to, source code, object code,\n\
+documentation and other files maintained in the Eclipse Foundation source code\n\
+repository ("Repository") in software modules ("Modules") and made available\n\
+as downloadable archives ("Downloads").\n\
+\n\
+\t- Content may be structured and packaged into modules to facilitate delivering,\n\
+\t  extending, and upgrading the Content. Typical modules may include plug-ins ("Plug-ins"),\n\
+\t  plug-in fragments ("Fragments"), and features ("Features").\n\
+\t- Each Plug-in or Fragment may be packaged as a sub-directory or JAR (Java(TM) ARchive)\n\
+\t  in a directory named "plugins".\n\
+\t- A Feature is a bundle of one or more Plug-ins and/or Fragments and associated material.\n\
+\t  Each Feature may be packaged as a sub-directory in a directory named "features".\n\
+\t  Within a Feature, files named "feature.xml" may contain a list of the names and version\n\
+\t  numbers of the Plug-ins and/or Fragments associated with that Feature.\n\
+\t- Features may also include other Features ("Included Features"). Within a Feature, files\n\
+\t  named "feature.xml" may contain a list of the names and version numbers of Included Features.\n\
+\n\
+The terms and conditions governing Plug-ins and Fragments should be\n\
+contained in files named "about.html" ("Abouts"). The terms and\n\
+conditions governing Features and Included Features should be contained\n\
+in files named "license.html" ("Feature Licenses"). Abouts and Feature\n\
+Licenses may be located in any directory of a Download or Module\n\
+including, but not limited to the following locations:\n\
+\n\
+\t- The top-level (root) directory\n\
+\t- Plug-in and Fragment directories\n\
+\t- Inside Plug-ins and Fragments packaged as JARs\n\
+\t- Sub-directories of the directory named "src" of certain Plug-ins\n\
+\t- Feature directories\n\
+\n\
+Note: if a Feature made available by the Eclipse Foundation is installed using the\n\
+Provisioning Technology (as defined below), you must agree to a license ("Feature \n\
+Update License") during the installation process. If the Feature contains\n\
+Included Features, the Feature Update License should either provide you\n\
+with the terms and conditions governing the Included Features or inform\n\
+you where you can locate them. Feature Update Licenses may be found in\n\
+the "license" property of files named "feature.properties" found within a Feature.\n\
+Such Abouts, Feature Licenses, and Feature Update Licenses contain the\n\
+terms and conditions (or references to such terms and conditions) that\n\
+govern your use of the associated Content in that directory.\n\
+\n\
+THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER\n\
+TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS.\n\
+SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
+\n\
+\t- Eclipse Distribution License Version 1.0 (available at http://www.eclipse.org/licenses/edl-v1.0.html)\n\
+\t- Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
+\t- Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
+\t- Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+\t- Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\
+\n\
+IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR\n\
+TO USE OF THE CONTENT. If no About, Feature License, or Feature Update License\n\
+is provided, please contact the Eclipse Foundation to determine what terms and conditions\n\
+govern that particular Content.\n\
+\n\
+\n\Use of Provisioning Technology\n\
+\n\
+The Eclipse Foundation makes available provisioning software, examples of which include,\n\
+but are not limited to, p2 and the Eclipse Update Manager ("Provisioning Technology") for\n\
+the purpose of allowing users to install software, documentation, information and/or\n\
+other materials (collectively "Installable Software"). This capability is provided with\n\
+the intent of allowing such users to install, extend and update Eclipse-based products.\n\
+Information about packaging Installable Software is available at\n\
+http://eclipse.org/equinox/p2/repository_packaging.html ("Specification").\n\
+\n\
+You may use Provisioning Technology to allow other parties to install Installable Software.\n\
+You shall be responsible for enabling the applicable license agreements relating to the\n\
+Installable Software to be presented to, and accepted by, the users of the Provisioning Technology\n\
+in accordance with the Specification. By using Provisioning Technology in such a manner and\n\
+making it available in accordance with the Specification, you further acknowledge your\n\
+agreement to, and the acquisition of all necessary rights to permit the following:\n\
+\n\
+\t1. A series of actions may occur ("Provisioning Process") in which a user may execute\n\
+\t   the Provisioning Technology on a machine ("Target Machine") with the intent of installing,\n\
+\t   extending or updating the functionality of an Eclipse-based product.\n\
+\t2. During the Provisioning Process, the Provisioning Technology may cause third party\n\
+\t   Installable Software or a portion thereof to be accessed and copied to the Target Machine.\n\
+\t3. Pursuant to the Specification, you will provide to the user the terms and conditions that\n\
+\t   govern the use of the Installable Software ("Installable Software Agreement") and such\n\
+\t   Installable Software Agreement shall be accessed from the Target Machine in accordance\n\
+\t   with the Specification. Such Installable Software Agreement must inform the user of the\n\
+\t   terms and conditions that govern the Installable Software and must solicit acceptance by\n\
+\t   the end user in the manner prescribed in such Installable Software Agreement. Upon such\n\
+\t   indication of agreement by the user, the provisioning Technology will complete installation\n\
+\t   of the Installable Software.\n\
+\n\
+Cryptography\n\
+\n\
+Content may contain encryption software. The country in which you are\n\
+currently may have restrictions on the import, possession, and use,\n\
+and/or re-export to another country, of encryption software. BEFORE\n\
+using any encryption software, please check the country's laws,\n\
+regulations and policies concerning the import, possession, or use, and\n\
+re-export of encryption software, to see if this is permitted.\n\
+\n\
+Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.\n
+########### end of license property ##########################################

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt211.feature/feature.xml
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt211.feature/feature.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="com.gwtplugins.eclipse.sdkbundle.gwt211.feature"
+      label="%featureName"
+      version="2.11.0.qualifier"
+      provider-name="%providerName">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      Copyright 2015 to 2024
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <url>
+      <update label="GWT Eclipse Plugin Update Site" url="http://storage.googleapis.com/gwt-eclipse-plugin/v3/release"/>
+   </url>
+
+   <plugin
+         id="com.gwtplugins.gwt.eclipse.sdkbundle.gwt211"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+</feature>

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt211.feature/pom.xml
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt211.feature/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.gwtplugins.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <artifactId>com.gwtplugins.eclipse.sdkbundle.gwt211.feature</artifactId>
+  <version>2.11.0-SNAPSHOT</version>
+  <packaging>eclipse-feature</packaging>
+
+</project>

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/.project
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.gwtplugins.eclipse.sdkbundle.gwt28.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/.settings/org.eclipse.m2e.core.prefs
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/build.properties
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/build.properties
@@ -1,0 +1,3 @@
+bin.includes = feature.xml,\
+               feature.properties
+               

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/feature.properties
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/feature.properties
@@ -1,0 +1,131 @@
+featureName  = GWT 2.8.2 SDK
+providerName = GWT Eclipse Plugin
+description = Downloads the GWT 2.8.2 SDK library 
+licenseURL = https://github.com/gwt-plugins/gwt-eclipse-plugin/blob/master/LICENSE.md
+
+# "license" property - text of the "Feature Update License"
+# should be plain text version of license agreement pointed to be "licenseURL"
+license=\
+Eclipse Foundation Software User Agreement\n\
+April 9, 2014\n\
+\n\
+Usage Of Content\n\
+\n\
+THE ECLIPSE FOUNDATION MAKES AVAILABLE SOFTWARE, DOCUMENTATION, INFORMATION AND/OR\n\
+OTHER MATERIALS FOR OPEN SOURCE PROJECTS (COLLECTIVELY "CONTENT").\n\
+USE OF THE CONTENT IS GOVERNED BY THE TERMS AND CONDITIONS OF THIS\n\
+AGREEMENT AND/OR THE TERMS AND CONDITIONS OF LICENSE AGREEMENTS OR\n\
+NOTICES INDICATED OR REFERENCED BELOW.  BY USING THE CONTENT, YOU\n\
+AGREE THAT YOUR USE OF THE CONTENT IS GOVERNED BY THIS AGREEMENT\n\
+AND/OR THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS\n\
+OR NOTICES INDICATED OR REFERENCED BELOW.  IF YOU DO NOT AGREE TO THE\n\
+TERMS AND CONDITIONS OF THIS AGREEMENT AND THE TERMS AND CONDITIONS\n\
+OF ANY APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED\n\
+BELOW, THEN YOU MAY NOT USE THE CONTENT.\n\
+\n\
+Applicable Licenses\n\
+\n\
+Unless otherwise indicated, all Content made available by the\n\
+Eclipse Foundation is provided to you under the terms and conditions of\n\
+the Eclipse Public License Version 1.0 ("EPL"). A copy of the EPL is\n\
+provided with this Content and is also available at http://www.eclipse.org/legal/epl-v10.html.\n\
+For purposes of the EPL, "Program" will mean the Content.\n\
+\n\
+Content includes, but is not limited to, source code, object code,\n\
+documentation and other files maintained in the Eclipse Foundation source code\n\
+repository ("Repository") in software modules ("Modules") and made available\n\
+as downloadable archives ("Downloads").\n\
+\n\
+\t- Content may be structured and packaged into modules to facilitate delivering,\n\
+\t  extending, and upgrading the Content. Typical modules may include plug-ins ("Plug-ins"),\n\
+\t  plug-in fragments ("Fragments"), and features ("Features").\n\
+\t- Each Plug-in or Fragment may be packaged as a sub-directory or JAR (Java(TM) ARchive)\n\
+\t  in a directory named "plugins".\n\
+\t- A Feature is a bundle of one or more Plug-ins and/or Fragments and associated material.\n\
+\t  Each Feature may be packaged as a sub-directory in a directory named "features".\n\
+\t  Within a Feature, files named "feature.xml" may contain a list of the names and version\n\
+\t  numbers of the Plug-ins and/or Fragments associated with that Feature.\n\
+\t- Features may also include other Features ("Included Features"). Within a Feature, files\n\
+\t  named "feature.xml" may contain a list of the names and version numbers of Included Features.\n\
+\n\
+The terms and conditions governing Plug-ins and Fragments should be\n\
+contained in files named "about.html" ("Abouts"). The terms and\n\
+conditions governing Features and Included Features should be contained\n\
+in files named "license.html" ("Feature Licenses"). Abouts and Feature\n\
+Licenses may be located in any directory of a Download or Module\n\
+including, but not limited to the following locations:\n\
+\n\
+\t- The top-level (root) directory\n\
+\t- Plug-in and Fragment directories\n\
+\t- Inside Plug-ins and Fragments packaged as JARs\n\
+\t- Sub-directories of the directory named "src" of certain Plug-ins\n\
+\t- Feature directories\n\
+\n\
+Note: if a Feature made available by the Eclipse Foundation is installed using the\n\
+Provisioning Technology (as defined below), you must agree to a license ("Feature \n\
+Update License") during the installation process. If the Feature contains\n\
+Included Features, the Feature Update License should either provide you\n\
+with the terms and conditions governing the Included Features or inform\n\
+you where you can locate them. Feature Update Licenses may be found in\n\
+the "license" property of files named "feature.properties" found within a Feature.\n\
+Such Abouts, Feature Licenses, and Feature Update Licenses contain the\n\
+terms and conditions (or references to such terms and conditions) that\n\
+govern your use of the associated Content in that directory.\n\
+\n\
+THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER\n\
+TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS.\n\
+SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
+\n\
+\t- Eclipse Distribution License Version 1.0 (available at http://www.eclipse.org/licenses/edl-v1.0.html)\n\
+\t- Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
+\t- Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
+\t- Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+\t- Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\
+\n\
+IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR\n\
+TO USE OF THE CONTENT. If no About, Feature License, or Feature Update License\n\
+is provided, please contact the Eclipse Foundation to determine what terms and conditions\n\
+govern that particular Content.\n\
+\n\
+\n\Use of Provisioning Technology\n\
+\n\
+The Eclipse Foundation makes available provisioning software, examples of which include,\n\
+but are not limited to, p2 and the Eclipse Update Manager ("Provisioning Technology") for\n\
+the purpose of allowing users to install software, documentation, information and/or\n\
+other materials (collectively "Installable Software"). This capability is provided with\n\
+the intent of allowing such users to install, extend and update Eclipse-based products.\n\
+Information about packaging Installable Software is available at\n\
+http://eclipse.org/equinox/p2/repository_packaging.html ("Specification").\n\
+\n\
+You may use Provisioning Technology to allow other parties to install Installable Software.\n\
+You shall be responsible for enabling the applicable license agreements relating to the\n\
+Installable Software to be presented to, and accepted by, the users of the Provisioning Technology\n\
+in accordance with the Specification. By using Provisioning Technology in such a manner and\n\
+making it available in accordance with the Specification, you further acknowledge your\n\
+agreement to, and the acquisition of all necessary rights to permit the following:\n\
+\n\
+\t1. A series of actions may occur ("Provisioning Process") in which a user may execute\n\
+\t   the Provisioning Technology on a machine ("Target Machine") with the intent of installing,\n\
+\t   extending or updating the functionality of an Eclipse-based product.\n\
+\t2. During the Provisioning Process, the Provisioning Technology may cause third party\n\
+\t   Installable Software or a portion thereof to be accessed and copied to the Target Machine.\n\
+\t3. Pursuant to the Specification, you will provide to the user the terms and conditions that\n\
+\t   govern the use of the Installable Software ("Installable Software Agreement") and such\n\
+\t   Installable Software Agreement shall be accessed from the Target Machine in accordance\n\
+\t   with the Specification. Such Installable Software Agreement must inform the user of the\n\
+\t   terms and conditions that govern the Installable Software and must solicit acceptance by\n\
+\t   the end user in the manner prescribed in such Installable Software Agreement. Upon such\n\
+\t   indication of agreement by the user, the provisioning Technology will complete installation\n\
+\t   of the Installable Software.\n\
+\n\
+Cryptography\n\
+\n\
+Content may contain encryption software. The country in which you are\n\
+currently may have restrictions on the import, possession, and use,\n\
+and/or re-export to another country, of encryption software. BEFORE\n\
+using any encryption software, please check the country's laws,\n\
+regulations and policies concerning the import, possession, or use, and\n\
+re-export of encryption software, to see if this is permitted.\n\
+\n\
+Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.\n
+########### end of license property ##########################################

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/feature.xml
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/feature.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="com.gwtplugins.eclipse.sdkbundle.gwt28.feature"
+      label="%featureName"
+      version="2.8.0.qualifier"
+      provider-name="%providerName">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      Copyright 2015 to 2017
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <url>
+      <update label="GWT Eclipse Plugin Update Site" url="http://storage.googleapis.com/gwt-eclipse-plugin/v3/release"/>
+   </url>
+
+   <plugin
+         id="com.gwtplugins.gwt.eclipse.sdkbundle.gwt28"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+</feature>

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/pom.xml
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.gwtplugins.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <artifactId>com.gwtplugins.eclipse.sdkbundle.gwt28.feature</artifactId>
+  <version>2.8.0-SNAPSHOT</version>
+  <packaging>eclipse-feature</packaging>
+
+</project>

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/.project
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.gwtplugins.eclipse.sdkbundle.gwt29.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/.settings/org.eclipse.m2e.core.prefs
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/build.properties
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/build.properties
@@ -1,0 +1,3 @@
+bin.includes = feature.xml,\
+               feature.properties
+               

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/feature.properties
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/feature.properties
@@ -1,0 +1,131 @@
+featureName  = GWT 2.9.0 SDK
+providerName = GWT Eclipse Plugin
+description = Downloads the GWT 2.9.0 SDK library 
+licenseURL = https://github.com/gwt-plugins/gwt-eclipse-plugin/blob/master/LICENSE.md
+
+# "license" property - text of the "Feature Update License"
+# should be plain text version of license agreement pointed to be "licenseURL"
+license=\
+Eclipse Foundation Software User Agreement\n\
+April 9, 2014\n\
+\n\
+Usage Of Content\n\
+\n\
+THE ECLIPSE FOUNDATION MAKES AVAILABLE SOFTWARE, DOCUMENTATION, INFORMATION AND/OR\n\
+OTHER MATERIALS FOR OPEN SOURCE PROJECTS (COLLECTIVELY "CONTENT").\n\
+USE OF THE CONTENT IS GOVERNED BY THE TERMS AND CONDITIONS OF THIS\n\
+AGREEMENT AND/OR THE TERMS AND CONDITIONS OF LICENSE AGREEMENTS OR\n\
+NOTICES INDICATED OR REFERENCED BELOW.  BY USING THE CONTENT, YOU\n\
+AGREE THAT YOUR USE OF THE CONTENT IS GOVERNED BY THIS AGREEMENT\n\
+AND/OR THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS\n\
+OR NOTICES INDICATED OR REFERENCED BELOW.  IF YOU DO NOT AGREE TO THE\n\
+TERMS AND CONDITIONS OF THIS AGREEMENT AND THE TERMS AND CONDITIONS\n\
+OF ANY APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED\n\
+BELOW, THEN YOU MAY NOT USE THE CONTENT.\n\
+\n\
+Applicable Licenses\n\
+\n\
+Unless otherwise indicated, all Content made available by the\n\
+Eclipse Foundation is provided to you under the terms and conditions of\n\
+the Eclipse Public License Version 1.0 ("EPL"). A copy of the EPL is\n\
+provided with this Content and is also available at http://www.eclipse.org/legal/epl-v10.html.\n\
+For purposes of the EPL, "Program" will mean the Content.\n\
+\n\
+Content includes, but is not limited to, source code, object code,\n\
+documentation and other files maintained in the Eclipse Foundation source code\n\
+repository ("Repository") in software modules ("Modules") and made available\n\
+as downloadable archives ("Downloads").\n\
+\n\
+\t- Content may be structured and packaged into modules to facilitate delivering,\n\
+\t  extending, and upgrading the Content. Typical modules may include plug-ins ("Plug-ins"),\n\
+\t  plug-in fragments ("Fragments"), and features ("Features").\n\
+\t- Each Plug-in or Fragment may be packaged as a sub-directory or JAR (Java(TM) ARchive)\n\
+\t  in a directory named "plugins".\n\
+\t- A Feature is a bundle of one or more Plug-ins and/or Fragments and associated material.\n\
+\t  Each Feature may be packaged as a sub-directory in a directory named "features".\n\
+\t  Within a Feature, files named "feature.xml" may contain a list of the names and version\n\
+\t  numbers of the Plug-ins and/or Fragments associated with that Feature.\n\
+\t- Features may also include other Features ("Included Features"). Within a Feature, files\n\
+\t  named "feature.xml" may contain a list of the names and version numbers of Included Features.\n\
+\n\
+The terms and conditions governing Plug-ins and Fragments should be\n\
+contained in files named "about.html" ("Abouts"). The terms and\n\
+conditions governing Features and Included Features should be contained\n\
+in files named "license.html" ("Feature Licenses"). Abouts and Feature\n\
+Licenses may be located in any directory of a Download or Module\n\
+including, but not limited to the following locations:\n\
+\n\
+\t- The top-level (root) directory\n\
+\t- Plug-in and Fragment directories\n\
+\t- Inside Plug-ins and Fragments packaged as JARs\n\
+\t- Sub-directories of the directory named "src" of certain Plug-ins\n\
+\t- Feature directories\n\
+\n\
+Note: if a Feature made available by the Eclipse Foundation is installed using the\n\
+Provisioning Technology (as defined below), you must agree to a license ("Feature \n\
+Update License") during the installation process. If the Feature contains\n\
+Included Features, the Feature Update License should either provide you\n\
+with the terms and conditions governing the Included Features or inform\n\
+you where you can locate them. Feature Update Licenses may be found in\n\
+the "license" property of files named "feature.properties" found within a Feature.\n\
+Such Abouts, Feature Licenses, and Feature Update Licenses contain the\n\
+terms and conditions (or references to such terms and conditions) that\n\
+govern your use of the associated Content in that directory.\n\
+\n\
+THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER\n\
+TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS.\n\
+SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
+\n\
+\t- Eclipse Distribution License Version 1.0 (available at http://www.eclipse.org/licenses/edl-v1.0.html)\n\
+\t- Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
+\t- Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
+\t- Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+\t- Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\
+\n\
+IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR\n\
+TO USE OF THE CONTENT. If no About, Feature License, or Feature Update License\n\
+is provided, please contact the Eclipse Foundation to determine what terms and conditions\n\
+govern that particular Content.\n\
+\n\
+\n\Use of Provisioning Technology\n\
+\n\
+The Eclipse Foundation makes available provisioning software, examples of which include,\n\
+but are not limited to, p2 and the Eclipse Update Manager ("Provisioning Technology") for\n\
+the purpose of allowing users to install software, documentation, information and/or\n\
+other materials (collectively "Installable Software"). This capability is provided with\n\
+the intent of allowing such users to install, extend and update Eclipse-based products.\n\
+Information about packaging Installable Software is available at\n\
+http://eclipse.org/equinox/p2/repository_packaging.html ("Specification").\n\
+\n\
+You may use Provisioning Technology to allow other parties to install Installable Software.\n\
+You shall be responsible for enabling the applicable license agreements relating to the\n\
+Installable Software to be presented to, and accepted by, the users of the Provisioning Technology\n\
+in accordance with the Specification. By using Provisioning Technology in such a manner and\n\
+making it available in accordance with the Specification, you further acknowledge your\n\
+agreement to, and the acquisition of all necessary rights to permit the following:\n\
+\n\
+\t1. A series of actions may occur ("Provisioning Process") in which a user may execute\n\
+\t   the Provisioning Technology on a machine ("Target Machine") with the intent of installing,\n\
+\t   extending or updating the functionality of an Eclipse-based product.\n\
+\t2. During the Provisioning Process, the Provisioning Technology may cause third party\n\
+\t   Installable Software or a portion thereof to be accessed and copied to the Target Machine.\n\
+\t3. Pursuant to the Specification, you will provide to the user the terms and conditions that\n\
+\t   govern the use of the Installable Software ("Installable Software Agreement") and such\n\
+\t   Installable Software Agreement shall be accessed from the Target Machine in accordance\n\
+\t   with the Specification. Such Installable Software Agreement must inform the user of the\n\
+\t   terms and conditions that govern the Installable Software and must solicit acceptance by\n\
+\t   the end user in the manner prescribed in such Installable Software Agreement. Upon such\n\
+\t   indication of agreement by the user, the provisioning Technology will complete installation\n\
+\t   of the Installable Software.\n\
+\n\
+Cryptography\n\
+\n\
+Content may contain encryption software. The country in which you are\n\
+currently may have restrictions on the import, possession, and use,\n\
+and/or re-export to another country, of encryption software. BEFORE\n\
+using any encryption software, please check the country's laws,\n\
+regulations and policies concerning the import, possession, or use, and\n\
+re-export of encryption software, to see if this is permitted.\n\
+\n\
+Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.\n
+########### end of license property ##########################################

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/feature.xml
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/feature.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="com.gwtplugins.eclipse.sdkbundle.gwt29.feature"
+      label="%featureName"
+      version="2.9.0.qualifier"
+      provider-name="%providerName">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      Copyright 2015 to 2017
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <url>
+      <update label="GWT Eclipse Plugin Update Site" url="http://storage.googleapis.com/gwt-eclipse-plugin/v3/release"/>
+   </url>
+
+   <plugin
+         id="com.gwtplugins.gwt.eclipse.sdkbundle.gwt29"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+</feature>

--- a/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/pom.xml
+++ b/features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.gwtplugins.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <artifactId>com.gwtplugins.eclipse.sdkbundle.gwt29.feature</artifactId>
+  <version>2.9.0-SNAPSHOT</version>
+  <packaging>eclipse-feature</packaging>
+
+</project>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/.project
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.gwtplugins.gwt.eclipse.sdkbundle.gwt210</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/.settings/org.eclipse.m2e.core.prefs
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %pluginName
+Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.sdkbundle.gwt210;singleton:=true
+Bundle-Version: 2.10.1.qualifier
+Bundle-Vendor: %providerName
+Require-Bundle: org.eclipse.core.runtime
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-ActivationPolicy: lazy
+Eclipse-BundleShape: dir

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/SdkBundleRegistrant.properties
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/SdkBundleRegistrant.properties
@@ -1,0 +1,2 @@
+sdkBundlePath=gwt-2.10.1
+sdkType=GWT 2.10.1

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/build.properties
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/build.properties
@@ -1,0 +1,7 @@
+output.. = bin/
+bin.includes = META-INF/,\
+               plugin.xml,\
+               SdkBundleRegistrant.properties,\
+               gwt-2.10.1/
+javacSource=11
+javacTarget=11

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/plugin.properties
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/plugin.properties
@@ -1,0 +1,4 @@
+pluginName=GWT 2.10.1 SDK
+providerName=GWT Eclipse Plugin
+
+

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/plugin.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/plugin.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+<plugin>  
+
+</plugin>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.gwtplugins.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <artifactId>com.gwtplugins.gwt.eclipse.sdkbundle.gwt210</artifactId>
+  <version>2.10.1-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.googlecode.maven-download-plugin</groupId>
+        <artifactId>download-maven-plugin</artifactId>
+        <version>1.2.1</version>
+        <executions>
+          <execution>
+            <id>get-gwt</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/gwtproject/gwt/releases/download/2.10.1/gwt-2.10.1.zip</url> 
+              <unpack>true</unpack>
+              <overwrite>true</overwrite>
+              <outputFileName>gwt-2.10.1.zip</outputFileName>
+              <outputDirectory>${basedir}</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build 
+          itself. -->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>com.googlecode.maven-download-plugin</groupId>
+                    <artifactId>download-maven-plugin</artifactId>
+                    <versionRange>[1.2.1,)</versionRange>
+                    <goals>
+                      <goal>wget</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt211/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt211/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %pluginName
+Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.sdkbundle.gwt211;singleton:=true
+Bundle-Version: 2.11.0.qualifier
+Bundle-Vendor: %providerName
+Require-Bundle: org.eclipse.core.runtime
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-ActivationPolicy: lazy
+Eclipse-BundleShape: dir

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt211/SdkBundleRegistrant.properties
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt211/SdkBundleRegistrant.properties
@@ -1,0 +1,2 @@
+sdkBundlePath=gwt-2.11.0
+sdkType=GWT 2.11.0

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt211/build.properties
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt211/build.properties
@@ -1,0 +1,7 @@
+output.. = bin/
+bin.includes = META-INF/,\
+               plugin.xml,\
+               SdkBundleRegistrant.properties,\
+               gwt-2.11.0/
+javacSource=11
+javacTarget=11

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt211/plugin.properties
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt211/plugin.properties
@@ -1,0 +1,4 @@
+pluginName=GWT 2.11.0 SDK
+providerName=GWT Eclipse Plugin
+
+

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt211/plugin.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt211/plugin.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+<plugin>  
+
+</plugin>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt211/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt211/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.gwtplugins.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <artifactId>com.gwtplugins.gwt.eclipse.sdkbundle.gwt211</artifactId>
+  <version>2.11.0-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.googlecode.maven-download-plugin</groupId>
+        <artifactId>download-maven-plugin</artifactId>
+        <version>1.6.8</version>
+        <executions>
+          <execution>
+            <id>get-gwt</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/gwtproject/gwt/releases/download/2.11.0/gwt-2.11.0.zip</url> 
+              <unpack>true</unpack>
+              <overwrite>true</overwrite>
+              <outputFileName>gwt-2.11.0.zip</outputFileName>
+              <outputDirectory>${basedir}</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build 
+          itself. -->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>com.googlecode.maven-download-plugin</groupId>
+                    <artifactId>download-maven-plugin</artifactId>
+                    <versionRange>[1.2.1,)</versionRange>
+                    <goals>
+                      <goal>wget</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/.project
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.gwtplugins.gwt.eclipse.sdkbundle.gwt28</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,10 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/.settings/org.eclipse.m2e.core.prefs
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %pluginName
+Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.sdkbundle.gwt28;singleton:=true
+Bundle-Version: 2.8.0.qualifier
+Bundle-Vendor: %providerName
+Require-Bundle: org.eclipse.core.runtime
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-ActivationPolicy: lazy
+Eclipse-BundleShape: dir

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/SdkBundleRegistrant.properties
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/SdkBundleRegistrant.properties
@@ -1,0 +1,2 @@
+sdkBundlePath=gwt-2.8.2
+sdkType=GWT 2.8.2

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/build.properties
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/build.properties
@@ -1,0 +1,7 @@
+output.. = bin/
+bin.includes = META-INF/,\
+               plugin.xml,\
+               SdkBundleRegistrant.properties,\
+               gwt-2.8.2/
+javacSource=11
+javacTarget=11

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/plugin.properties
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/plugin.properties
@@ -1,0 +1,4 @@
+pluginName=GWT 2.8.2 SDK
+providerName=GWT Eclipse Plugin
+
+

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/plugin.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/plugin.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+<plugin>  
+
+</plugin>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.gwtplugins.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <artifactId>com.gwtplugins.gwt.eclipse.sdkbundle.gwt28</artifactId>
+  <version>2.8.0-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.googlecode.maven-download-plugin</groupId>
+        <artifactId>download-maven-plugin</artifactId>
+        <version>1.2.1</version>
+        <executions>
+          <execution>
+            <id>get-gwt</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://goo.gl/pZZPXS</url> 
+              <unpack>true</unpack>
+              <overwrite>true</overwrite>
+              <outputFileName>gwt-2.8.2.zip</outputFileName>
+              <outputDirectory>${basedir}</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build 
+          itself. -->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>com.googlecode.maven-download-plugin</groupId>
+                    <artifactId>download-maven-plugin</artifactId>
+                    <versionRange>[1.2.1,)</versionRange>
+                    <goals>
+                      <goal>wget</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/.project
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.gwtplugins.gwt.eclipse.sdkbundle.gwt29</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/.settings/org.eclipse.m2e.core.prefs
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/META-INF/MANIFEST.MF
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %pluginName
+Bundle-SymbolicName: com.gwtplugins.gwt.eclipse.sdkbundle.gwt29;singleton:=true
+Bundle-Version: 2.9.0.qualifier
+Bundle-Vendor: %providerName
+Require-Bundle: org.eclipse.core.runtime
+Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-ActivationPolicy: lazy
+Eclipse-BundleShape: dir

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/SdkBundleRegistrant.properties
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/SdkBundleRegistrant.properties
@@ -1,0 +1,2 @@
+sdkBundlePath=gwt-2.9.0
+sdkType=GWT 2.9.0

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/build.properties
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/build.properties
@@ -1,0 +1,7 @@
+output.. = bin/
+bin.includes = META-INF/,\
+               plugin.xml,\
+               SdkBundleRegistrant.properties,\
+               gwt-2.9.0/
+javacSource=11
+javacTarget=11

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/plugin.properties
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/plugin.properties
@@ -1,0 +1,4 @@
+pluginName=GWT 2.9.0 SDK
+providerName=GWT Eclipse Plugin
+
+

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/plugin.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/plugin.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+<plugin>  
+
+</plugin>

--- a/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/pom.xml
+++ b/plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.gwtplugins.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <artifactId>com.gwtplugins.gwt.eclipse.sdkbundle.gwt29</artifactId>
+  <version>2.9.0-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.googlecode.maven-download-plugin</groupId>
+        <artifactId>download-maven-plugin</artifactId>
+        <version>1.2.1</version>
+        <executions>
+          <execution>
+            <id>get-gwt</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://storage.googleapis.com/gwt-releases/gwt-2.9.0.zip</url> 
+              <unpack>true</unpack>
+              <overwrite>true</overwrite>
+              <outputFileName>gwt-2.9.0.zip</outputFileName>
+              <outputDirectory>${basedir}</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build 
+          itself. -->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>com.googlecode.maven-download-plugin</groupId>
+                    <artifactId>download-maven-plugin</artifactId>
+                    <versionRange>[1.2.1,)</versionRange>
+                    <goals>
+                      <goal>wget</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.gwtplugins.eclipse</groupId>
+  <artifactId>trunk</artifactId>
+  <version>4.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <tycho.version>3.0.1</tycho.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <eclipse.target>2022-09</eclipse.target> <!-- TODO change to neon -->
+
+    <!-- Repositories that Tycho will use to resolve compilation dependencies. -->
+    <eclipse-repo.url>https://download.eclipse.org/releases/${eclipse.target}</eclipse-repo.url>
+    <webtools-repo.url>https://download.eclipse.org/webtools/repository/${eclipse.target}</webtools-repo.url>
+
+    <!-- Release url determined by upload in upload-release.sh -->
+    <comparator.repo>http://storage.googleapis.com/gwt-eclipse-plugin/v3/release</comparator.repo>
+
+    <!-- OS-specific JVM flags, empty for the default case but redefined below -->
+    <os-jvm-flags />
+
+    <!-- Skip the deployment here, submodules can override this property -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+    
+  </properties>
+
+  <modules>
+<!--    <module>resources</module> -->
+
+    <!-- Features located in ./repo/category.xml -->
+    <module>features/com.gwtplugins.eclipse.sdkbundle.gwt28.feature</module>
+    <module>features/com.gwtplugins.eclipse.sdkbundle.gwt29.feature</module>
+    <module>features/com.gwtplugins.eclipse.sdkbundle.gwt210.feature</module>
+    <module>features/com.gwtplugins.eclipse.sdkbundle.gwt211.feature</module>
+
+    <!-- SDK Bundles -->
+    <module>plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt28</module>
+    <module>plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt29</module>
+    <module>plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt210</module>
+    <module>plugins/com.gwtplugins.gwt.eclipse.sdkbundle.gwt211</module>
+
+    <!-- Use `mvn package` - repository located in ./repo/target/repository -->
+    <module>repo</module>
+  </modules>
+
+  <repositories>
+    <repository>
+      <id>eclipse</id>
+      <url>${eclipse-repo.url}</url>
+      <layout>p2</layout>
+    </repository>
+    <repository>
+      <id>webtools</id>
+      <url>${webtools-repo.url}</url>
+      <layout>p2</layout>
+    </repository>
+  </repositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.10.1</version>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-maven-plugin</artifactId>
+        <version>${tycho.version}</version>
+        <extensions>true</extensions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <configuration>
+          <filters>
+          </filters>
+          <environments>
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>x86</arch>
+            </environment>
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>win32</os>
+              <ws>win32</ws>
+              <arch>x86</arch>
+            </environment>
+            <environment>
+              <os>win32</os>
+              <ws>win32</ws>
+              <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>macosx</os>
+              <ws>cocoa</ws>
+              <arch>x86_64</arch>
+            </environment>
+          </environments>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-versions-plugin</artifactId>
+      </plugin>
+    </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-versions-plugin</artifactId>
+          <version>${tycho.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>target-platform-configuration</artifactId>
+          <version>${tycho.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-compiler-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <configuration>
+            <showWarnings>true</showWarnings>
+          </configuration>
+        </plugin>
+
+        <!-- https://eclipse.org/tycho/sitedocs/tycho-surefire/tycho-surefire-plugin/test-mojo.html -->
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-surefire-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <configuration>
+            <!-- https://wiki.eclipse.org/Tycho/FAQ#How_to_use_SWTBot_or_some_UI_tool_for_testing.3F -->
+            <useUIHarness>true</useUIHarness> <!-- https://wiki.eclipse.org/SWTBot/Automate_test_execution -->
+            <useUIThread>false</useUIThread>
+            <product>org.eclipse.sdk.ide</product>
+            <application>org.eclipse.ui.ide.workbench</application>
+            <argLine>-Dorg.eclipse.swtbot.search.timeout=${org.eclipse.swtbot.search.timeout} -Xms40m -Xmx1G -Djava.awt.headless=true ${os-jvm-flags}</argLine>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-p2-director-plugin</artifactId>
+          <version>${tycho.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-p2-repository-plugin</artifactId>
+          <version>${tycho.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-p2-plugin</artifactId>
+          <version>${tycho.version}</version>
+          <configuration>
+            <baselineMode>warn</baselineMode>
+            <baselineReplace>all</baselineReplace>
+            <baselineRepositories>
+              <repository>
+                <url>${comparator.repo}</url>
+              </repository>
+            </baselineRepositories>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>macosx-jvm-flags</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <properties>
+        <os-jvm-flags>-XstartOnFirstThread</os-jvm-flags>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>build-eclipse-2022-09</id>
+      <activation>
+        <property>
+          <name>eclipse.target</name>
+          <value>2022-09</value>
+        </property>
+      </activation>
+      <properties>
+      </properties>
+      <modules>
+        <module>eclipse/2022-09</module>
+      </modules>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>target-platform-configuration</artifactId>
+            <configuration>
+              <target>
+                <artifact>
+                  <groupId>com.gwtplugins.eclipse</groupId>
+                  <artifactId>gwt-eclipse-2022-09</artifactId>
+                  <version>4.25.0-SNAPSHOT</version>
+                </artifact>
+              </target>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <!-- create a copy of the build target platform, suitable for setting as an Eclipse Target Platform -->
+      <id>ide-target-platform</id>
+      <modules>
+        <module>eclipse/ide-target-platform</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>teamcity</id>
+      <properties>
+        <!-- We configure Travis to use jdk7 -->
+        <tycho.toolchains>SYSTEM</tycho.toolchains>
+        <!-- Ensure we don't resolve previous versions of our artifacts -->
+        <tycho.localArtifacts>ignore</tycho.localArtifacts>
+      </properties>
+      <modules>
+        <module>eclipse/ide-target-platform</module>
+        <module>build/verify-feature-completeness</module>
+      </modules>
+    </profile>
+  </profiles>
+</project>

--- a/repo/category.xml
+++ b/repo/category.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <feature id="com.gwtplugins.eclipse.sdkbundle.gwt28.feature" version="2.8.0.qualifier">
+      <category name="GWT_SDK"/>
+   </feature>
+   <feature id="com.gwtplugins.eclipse.sdkbundle.gwt29.feature" version="2.9.0.qualifier">
+      <category name="GWT_SDK"/>
+   </feature>
+   <feature id="com.gwtplugins.eclipse.sdkbundle.gwt210.feature" version="2.10.1.qualifier">
+      <category name="GWT_SDK"/>
+   </feature>
+   <feature id="com.gwtplugins.eclipse.sdkbundle.gwt211.feature" version="2.11.0.qualifier">
+      <category name="GWT_SDK"/>
+   </feature>
+   <category-def name="GWT_SDK" label="GWT SDK">
+      <description>
+         GWT SDKs
+      </description>
+   </category-def>
+</site>

--- a/repo/pom.xml
+++ b/repo/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.gwtplugins.eclipse</groupId>
+    <artifactId>trunk</artifactId>
+    <version>4.1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>repo</artifactId>
+  <packaging>eclipse-repository</packaging>
+
+  <build>
+    <resources>
+      <!-- Add these contents to the output directory or classes directory, then it gets moved to repository -->
+      <resource>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>**</include>
+        </includes>
+      </resource>
+    </resources>
+  
+    <plugins>
+      <!-- Assemble the Site -->
+      <!-- https://eclipse.org/tycho/sitedocs/tycho-p2/tycho-p2-repository-plugin/assemble-repository-mojo.html -->
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-repository-plugin</artifactId>
+        <configuration>
+          <includeAllDependencies>false</includeAllDependencies>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-director-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+


### PR DESCRIPTION
Updated my first attempt to include SDK 2.11 and removed 2.7.
This is made to fix issue 458 from gwt-eclipse-plugin.